### PR TITLE
Fix Issues to Cannot bind parameter Date to the Target if value is null

### DIFF
--- a/Get-CertTransparencyInfo.psm1
+++ b/Get-CertTransparencyInfo.psm1
@@ -183,7 +183,11 @@ Function Get-CertTransparencyInfo {
 			$tmpobj.name_value = $data.name_value
 			$tmpobj.issuer_name = $data.issuer_name
 			$tmpobj.not_before = get-date $data.not_before
-			$tmpobj.min_entry_timestamp = get-date $data.min_entry_timestamp
+			try {
+				$tmpobj.min_entry_timestamp = get-date $data.min_entry_timestamp
+			} catch {
+
+			}
 			$tmpobj.Cli_online_obj_url = "$($crtsh)?id=$($data.min_cert_id)"
 			$tmpobj.Cli_online_certificate_url = "$($crtsh)?d=$($data.min_cert_id)"
 			if ($advsearch) {$tmpobj.Cli_adv_search = $advsearch}


### PR DESCRIPTION
Hi , i'm currently running in a lot of issues so i've added an silently ignore to the date values. It seems there can be Null somehow...

0.4.0\Get-CertTransparencyInfo.psm1:186:43                                                                                     Line |                                                                                                                                                                                                           186 |  …      $tmpobj.min_entry_timestamp = get-date $data.min_entry_timestamp                                                                                                                                      |                                                ~~~~~~~~~~~~~~~~~~~~~~~~~                                                                                                                                      | Cannot bind parameter 'Date' to the target. Exception setting "Date": "Cannot convert null to type "System.DateTime"."    